### PR TITLE
add typings

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,8 @@
+import Vue, { PluginFunction } from "vue"
+import { DirectiveOptions } from 'vue/types/options'
+
+export const ObserveVisibility: DirectiveOptions
+
+export default class VueObserveVisibilityPlugin {
+	static install: PluginFunction<never>
+}


### PR DESCRIPTION
This PR adds a typescript definition file allowing typescript users to import and use this plugin without declaring module types themselves or suppressing missing type warnings.

You can merge and tag as-is since this is a non-functional change